### PR TITLE
[php7対応] clio: ComponentFactory#doCreateのsignitureを継承元クラスに合わせる.

### DIFF
--- a/clio/src/Clio/Component/Pattern/Factory/ComponentFactory.php
+++ b/clio/src/Clio/Component/Pattern/Factory/ComponentFactory.php
@@ -57,7 +57,7 @@ class ComponentFactory extends ClassFactory implements Factory
 	 * @access protected
 	 * @return void
 	 */
-	protected function doCreate(array $args)
+	protected function doCreate(array $args = array())
 	{
 		return $this->createComponent($args);
 	}


### PR DESCRIPTION
PHP7で以下のエラーが出ている。

```
PHP Fatal error:  Declaration of Clio\Component\Pattern\Factory\ComponentFactory::doCreate(array $args) must be compatible with Clio\Component\Pattern\Factory\ClassFactory::doCreate(array $args = Array) in /var/www/html/releases/20190503065502/library/vendor/musephp/musephp/clio/src/Clio/Component/Pattern/Factory/ComponentFactory.php on line 14
```

これは` Clio\Component\Pattern\Factory\ComponentFactory::doCreate`と`Clio\Component\Pattern\Factory\ClassFactory::doCreate`のsignitureが異なっていることが原因。

そこで`omponentFactory::doCreate`のsigunitureを`doCreate(array $args = array())`とした。
( 広める方向の変更なので、後方互換も問題ないはず )